### PR TITLE
Update target SDK and Capture client

### DIFF
--- a/examples/hellocapture-android/build.gradle
+++ b/examples/hellocapture-android/build.gradle
@@ -19,12 +19,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.example.socketmobile.android.hellocapture"
         minSdkVersion 15
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -37,9 +37,9 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.android.support:design:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.socketmobile:capture-android:1.0.0'
 
     testImplementation 'junit:junit:4.12'

--- a/examples/hellocapture-android/build.gradle
+++ b/examples/hellocapture-android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 
@@ -37,9 +37,9 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.android.support:design:28.0.0-rc02'
+    implementation 'com.android.support:design:28.0.0'
     implementation 'com.socketmobile:capture-android:1.0.0'
 
     testImplementation 'junit:junit:4.12'

--- a/examples/hellocapture-android/build.gradle
+++ b/examples/hellocapture-android/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'com.socketmobile:capture-android:1.0.0'
+    implementation 'com.socketmobile:capture-android:1.0.3'
 
     testImplementation 'junit:junit:4.12'
 }

--- a/examples/hellocapture-android/src/main/AndroidManifest.xml
+++ b/examples/hellocapture-android/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:fullBackupContent="@xml/backup_descriptor"

--- a/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/MainActivity.java
+++ b/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/MainActivity.java
@@ -2,7 +2,7 @@ package com.example.socketmobile.android.hellocapture;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.TextView;

--- a/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/NonCaptureActivity.java
+++ b/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/NonCaptureActivity.java
@@ -2,7 +2,7 @@ package com.example.socketmobile.android.hellocapture;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 public class NonCaptureActivity extends AppCompatActivity {

--- a/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/SecondCaptureActivity.java
+++ b/examples/hellocapture-android/src/main/java/com/example/socketmobile/android/hellocapture/SecondCaptureActivity.java
@@ -1,7 +1,7 @@
 package com.example.socketmobile.android.hellocapture;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.TextView;
 import com.socketmobile.capture.client.DataEvent;

--- a/examples/hellocapture-android/src/main/res/layout/activity_main.xml
+++ b/examples/hellocapture-android/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -57,4 +57,4 @@
         tools:ignore="HardcodedText"
         />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/hellocapture-android/src/main/res/layout/activity_second_capture.xml
+++ b/examples/hellocapture-android/src/main/res/layout/activity_second_capture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -72,4 +72,4 @@
         tools:ignore="HardcodedText"
         />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/hellocapture-android/src/main/res/xml/network_security_config.xml
+++ b/examples/hellocapture-android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">localhost</domain>
+    <domain includeSubdomains="false">127.0.0.1</domain>
+  </domain-config>
+</network-security-config>

--- a/examples/hellokapture-android/build.gradle
+++ b/examples/hellokapture-android/build.gradle
@@ -24,16 +24,16 @@ repositories {
 }
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion 29
 
   defaultConfig {
     applicationId "com.example.socketmobile.android.hellokapture"
     minSdkVersion 21
-    targetSdkVersion 28
+    targetSdkVersion 29
     versionCode 1
     versionName "1.0"
 
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   buildTypes {
@@ -46,13 +46,13 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation 'com.android.support:appcompat-v7:28.0.0'
-  implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+  implementation 'androidx.appcompat:appcompat:1.0.2'
+  implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
   implementation 'com.socketmobile:capture-android:1.0.0'
 
   testImplementation 'junit:junit:4.12'
 
-  androidTestImplementation 'com.android.support.test:runner:1.0.2'
-  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+  androidTestImplementation 'androidx.test:runner:1.2.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 

--- a/examples/hellokapture-android/build.gradle
+++ b/examples/hellokapture-android/build.gradle
@@ -48,7 +48,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation 'androidx.appcompat:appcompat:1.0.2'
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-  implementation 'com.socketmobile:capture-android:1.0.0'
+  implementation 'com.socketmobile:capture-android:1.0.3'
 
   testImplementation 'junit:junit:4.12'
 

--- a/examples/hellokapture-android/build.gradle
+++ b/examples/hellokapture-android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 buildscript {
-  ext.kotlin_version = '1.2.70'
+  ext.kotlin_version = '1.3.41'
 
   repositories {
     mavenCentral()
@@ -11,7 +11,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.4'
+    classpath 'com.android.tools.build:gradle:3.4.2'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
@@ -46,7 +46,7 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-  implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
+  implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation 'com.android.support.constraint:constraint-layout:1.1.3'
   implementation 'com.socketmobile:capture-android:1.0.0'
 

--- a/examples/hellokapture-android/src/androidTest/java/com/example/socketmobile/android/hellokapture/ExampleInstrumentedTest.kt
+++ b/examples/hellokapture-android/src/androidTest/java/com/example/socketmobile/android/hellokapture/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.example.socketmobile.android.hellokapture
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.InstrumentationRegistry
+import androidx.test.runner.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/examples/hellokapture-android/src/main/AndroidManifest.xml
+++ b/examples/hellokapture-android/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
+      android:networkSecurityConfig="@xml/network_security_config"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"

--- a/examples/hellokapture-android/src/main/java/com/example/socketmobile/android/hellokapture/MainActivity.kt
+++ b/examples/hellokapture-android/src/main/java/com/example/socketmobile/android/hellokapture/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.example.socketmobile.android.hellokapture
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import com.socketmobile.capture.android.Capture
 import com.socketmobile.capture.client.DataEvent

--- a/examples/hellokapture-android/src/main/res/layout/activity_main.xml
+++ b/examples/hellokapture-android/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -41,4 +41,4 @@
       tools:ignore="HardcodedText"
       />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/hellokapture-android/src/main/res/xml/network_security_config.xml
+++ b/examples/hellokapture-android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="false" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">localhost</domain>
+    <domain includeSubdomains="false">127.0.0.1</domain>
+  </domain-config>
+</network-security-config>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 14 12:54:49 HKT 2018
+#Fri Aug 09 11:42:54 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- Update the gradle plugin and other dependencies
- Target the latest version of Android
- Apply the necessary workaround for targeting Android 28+
- Update the sample apps to use the latest Capture client for Android